### PR TITLE
Add support for file-like objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented here.
 
 ## [Unreleased]
+### Added
+- Read & write wupport for file-like objects.
+
 ### Fixed
 - Documentation improved.
 


### PR DESCRIPTION
Resolves: #19 

The trickiest part of this so far was determining whether a given file-like object can be memory mapped.  If the current logic ends up being problematic, we may need to limit memory mapping to builtin types, or make it an opt-in feature in the worst case.