### PR TITLE
add uint64 and int64 to data type

### DIFF
--- a/plyfile.py
+++ b/plyfile.py
@@ -43,6 +43,8 @@ _data_type_relation = [
     ('int', 'i4'),
     ('uint32', 'u4'),
     ('uint', 'u4'),
+    ('int64', 'i8'),
+    ('uint64', 'u8'),
     ('float32', 'f4'),
     ('float', 'f4'),
     ('float64', 'f8'),


### PR DESCRIPTION
Tested as following.
```bash
(Pdb) plydata.elements[0]
PlyElement('rot', (PlyProperty('timestamp', 'int64'), PlyProperty('x', 'double'), PlyProperty('y', 'double'), PlyProperty('z', 'double')), count=2633, comments=['rot sensor data with timestamp'])
(Pdb) plydata.elements[0].data[0]
(5176470752137, -0.17772718, -0.3460772, -0.00874486)
```