### PR TITLE
Remove DeprecationWarnings related to ndarray.tostring

### DIFF
--- a/plyfile.py
+++ b/plyfile.py
@@ -990,7 +990,11 @@ def _read_array(stream, dtype, n):
 
 
 def _write_array(stream, array):
-    stream.write(array.tostring())
+    # ndarray.tostring is deprecated since numpy 1.19.0
+    try:
+        stream.write(array.tobytes())
+    except AttributeError:
+        stream.write(array.tostring())
 
 
 def _can_mmap(stream):


### PR DESCRIPTION
I recently updated `numpy` and noticed a large number of warnings during `plyfile` tests. The cause was the deprecation of [`ndarray.tostring`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tostring.html) in favor of [`ndarray.tobytes`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tobytes.html#numpy.ndarray.tobytes) as of `numpy` version 1.19.0.

Previously, running the tests with `py.test test -v` yielded:

```
test/test_plyfile.py: 332 warnings
  python-plyfile/plyfile.py:998: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
    stream.write(array.tostring())
```

This PR is a small fix that removes these warnings for new versions of `numpy` but preserves backward compatibility.