### PR TITLE
Accelerate PlyData.read when list properties have a known, fixed length

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,25 @@ Many (but not necessarily all) types of malformed input files will raise
 `PlyParseError` instance (as well as attributes `element`, `row`, and
 `prop`) provides additional context for the error if applicable.
 
+In many cases where a property is a list (e.g., "vertex_indices"), the
+length of the list may be fixed and known, e.g., for the triangular mesh
+described by `tet.ply`. The default for `PlyData.read` is to assume any
+lists can be of arbitrary length, which is what the PLY format supports,
+but that flexibility can make reading slow for large files. In the case
+where any lists have fixed, known length, the `list_len` kwarg has been
+added to `PlyData.read` to accelerate reading when the data are binary:
+
+```Python Console
+>>> plydata.text = False
+>>> plydata.byte_order = '<'
+>>> plydata.write('tet_binary.ply')
+>>> plydata = PlyData.read('tet_binary.ply', list_len=3)
+```
+
+If there is no `PlyParseError` raised, the code will check that all the
+lists that were read in have reported lengths equal to `list_len`, and if
+they do not match, a `PlyParseError` will be raised.
+
 ## Creating a PLY file
 
 The first step is to get your data into `numpy` structured arrays.  Note
@@ -186,7 +205,8 @@ format provides no way to find out that each "vertex_indices" field has
 length 3 without actually reading all the data, so `plyfile` has to
 assume that this is a variable-length property.  However, see below (and
 `examples/plot.py`) for an easy way to recover a two-dimensional array
-from a list property.
+from a list property, and also see the notes above about the `list_len`
+kwarg to speed up the reading of files with list of fixed known length.
 
 For example, if we wanted to create the "vertex" and "face" PLY elements
 of the `tet.ply` data directly as `numpy` arrays for the purpose of

--- a/README.md
+++ b/README.md
@@ -171,19 +171,20 @@ length of the list may be fixed and known, e.g., for the triangular mesh
 described by `tet.ply`. The default for `PlyData.read` is to assume any
 lists can be of arbitrary length, which is what the PLY format supports,
 but that flexibility can make reading slow for large files. In the case
-where any lists have fixed, known length, the `list_len` kwarg has been
-added to `PlyData.read` to accelerate reading when the data are binary:
+where any lists have fixed, known length, the `known_list_len` kwarg has
+been added to `PlyData.read` to accelerate reading when the data are
+binary:
 
 ```Python Console
 >>> plydata.text = False
 >>> plydata.byte_order = '<'
 >>> plydata.write('tet_binary.ply')
->>> plydata = PlyData.read('tet_binary.ply', list_len=3)
+>>> plydata = PlyData.read('tet_binary.ply', known_list_len=3)
 ```
 
 If there is no `PlyParseError` raised, the code will check that all the
-lists that were read in have reported lengths equal to `list_len`, and if
-they do not match, a `PlyParseError` will be raised.
+lists that were read in have reported lengths equal to `known_list_len`,
+and if they do not match, a `PlyParseError` will be raised.
 
 ## Creating a PLY file
 
@@ -205,8 +206,9 @@ format provides no way to find out that each "vertex_indices" field has
 length 3 without actually reading all the data, so `plyfile` has to
 assume that this is a variable-length property.  However, see below (and
 `examples/plot.py`) for an easy way to recover a two-dimensional array
-from a list property, and also see the notes above about the `list_len`
-kwarg to speed up the reading of files with list of fixed known length.
+from a list property, and also see the notes above about the
+`known_list_len` kwarg to speed up the reading of files with list of
+fixed, known length.
 
 For example, if we wanted to create the "vertex" and "face" PLY elements
 of the `tet.ply` data directly as `numpy` arrays for the purpose of

--- a/plyfile.py
+++ b/plyfile.py
@@ -683,7 +683,9 @@ class PlyElement(object):
             # remove any extra properties added
             if len(list_len_props) > 0:
                 for prop in list_len_props:
-                    assert (self._data[prop] == list_len).all()
+                    if not (self._data[prop] == list_len).all():
+                        raise PlyElementParseError("Unexpected list length: " +
+                                                   prop.name)
                 props = [p.name for p in self.properties]
                 self._data = self._data[props]
         else:

--- a/plyfile.py
+++ b/plyfile.py
@@ -688,7 +688,7 @@ class PlyElement(object):
                 for prop in list_len_props:
                     if not (self._data[prop] == known_list_len).all():
                         raise PlyElementParseError("Unexpected list length: " +
-                                                   prop.name)
+                                                   prop[:-4])
                 props = [p.name for p in self.properties]
                 self._data = self._data[props]
         else:

--- a/plyfile.py
+++ b/plyfile.py
@@ -652,6 +652,8 @@ class PlyElement(object):
             num_bytes = self.count * dtype.itemsize
             list_len_props = []
             if self._have_list and known_list_len:
+                assert isinstance(known_list_len, int)
+                assert known_list_len >= 1
                 # update the dtype to include the list length and list dtype
                 new_dtype = []
                 for j, p in enumerate(self.properties):

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -850,3 +850,19 @@ def test_mmap_option(tmpdir, tet_ply_txt):
     assert isinstance(tet_ply1['vertex'].data, numpy.memmap)
     tet_ply2 = PlyData.read(str(filename), mmap=False)
     assert not isinstance(tet_ply2['vertex'].data, numpy.memmap)
+
+
+def test_read_list_len_option(tmpdir, tet_ply_txt):
+    ply0 = tet_ply_txt
+    ply0.text = False
+    ply0.byte_order = '<'
+    test_file = tmpdir.join('test.ply')
+
+    with test_file.open('wb') as f:
+        tet_ply_txt.write(f)
+
+    print(help(PlyData.read))
+    ply1 = PlyData.read(str(test_file), list_len=None)
+    verify(ply0, ply1)
+    ply2 = PlyData.read(str(test_file), list_len=3)
+    verify(ply0, ply2)

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -866,3 +866,8 @@ def test_read_list_len_option(tmpdir, tet_ply_txt):
     verify(ply0, ply1)
     ply2 = PlyData.read(str(test_file), list_len=3)
     verify(ply0, ply2)
+
+    # test the result of an incorrect length
+    with Raises(PlyElementParseError) as e:
+        PlyData.read(str(test_file), list_len=4)
+    assert str(e) == "element 'face': row 3: early end-of-file"

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -866,7 +866,11 @@ def test_read_known_list_len_option(tmpdir, tet_ply_txt):
     ply2 = PlyData.read(str(test_file), known_list_len=3)
     verify(ply0, ply2)
 
-    # test the result of an incorrect length
+    # test the results of an incorrect length
     with Raises(PlyElementParseError) as e:
         PlyData.read(str(test_file), known_list_len=4)
     assert str(e) == "element 'face': row 3: early end-of-file"
+
+    with Raises(PlyElementParseError) as e:
+        PlyData.read(str(test_file), known_list_len=2)
+    assert str(e) == "Unexpected list length: vertex_indices"

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -859,9 +859,8 @@ def test_read_list_len_option(tmpdir, tet_ply_txt):
     test_file = tmpdir.join('test.ply')
 
     with test_file.open('wb') as f:
-        tet_ply_txt.write(f)
+        ply0.write(f)
 
-    print(help(PlyData.read))
     ply1 = PlyData.read(str(test_file), list_len=None)
     verify(ply0, ply1)
     ply2 = PlyData.read(str(test_file), list_len=3)

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -852,7 +852,7 @@ def test_mmap_option(tmpdir, tet_ply_txt):
     assert not isinstance(tet_ply2['vertex'].data, numpy.memmap)
 
 
-def test_read_list_len_option(tmpdir, tet_ply_txt):
+def test_read_known_list_len_option(tmpdir, tet_ply_txt):
     ply0 = tet_ply_txt
     ply0.text = False
     ply0.byte_order = '<'
@@ -861,12 +861,12 @@ def test_read_list_len_option(tmpdir, tet_ply_txt):
     with test_file.open('wb') as f:
         ply0.write(f)
 
-    ply1 = PlyData.read(str(test_file), list_len=None)
+    ply1 = PlyData.read(str(test_file), known_list_len=None)
     verify(ply0, ply1)
-    ply2 = PlyData.read(str(test_file), list_len=3)
+    ply2 = PlyData.read(str(test_file), known_list_len=3)
     verify(ply0, ply2)
 
     # test the result of an incorrect length
     with Raises(PlyElementParseError) as e:
-        PlyData.read(str(test_file), list_len=4)
+        PlyData.read(str(test_file), known_list_len=4)
     assert str(e) == "element 'face': row 3: early end-of-file"


### PR DESCRIPTION
Hi @dranjan , I recently ran into a limitation with large mesh files, that the read times can be very slow even for binary-encoded data. I put together a solution here for the case when any of the lists have a known, fixed length, in which case I made it so the code is still able to take advantage of `np.memmap`. For example, if a PLY file contains a triangular mesh, so the length of `vertex_indices` is always 3, one can now accelerate `PlyData.read` using `known_list_len=3`. I obtained a 40X speedup for reading in one large triangular mesh file I have.

Totally up to you whether you are interested in this feature but I thought I would put in a PR. Still getting lots of good use out of this package.

I just noticed this would fix #24.