### PR TITLE
Address some long-standing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented here.
 
 ## [Unreleased]
+### Removed
+- Python2-specific code paths.
+- `make2d` function (redundant with `numpy.vstack`).
 
 ## [0.8.1] - 2023-03-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented here.
 
 ## [Unreleased]
+### Added
+- Support for reading ASCII-format PLY files from text streams.
+
+### Fixed
+- Support for reading Mac-style line endings.
+
 ### Removed
 - Python2-specific code paths.
 - `make2d` function (redundant with `numpy.vstack`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented here.
 ### Added
 - Support for reading ASCII-format PLY files from text streams.
 
+### Changed
+- Docstring formatting style:
+  - better PEP-257 compliance;
+  - adoption of NumPy docstring style.
+
 ### Fixed
 - Support for reading Mac-style line endings.
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,14 @@ new instances and modifying in place).  For example, a single
 but modifying that instance will then affect all of those containing
 `PlyData` instances.
 
+### Text-mode streams
+
+Input and output on text-mode streams is supported for ASCII-format
+PLY files, but not binary-format PLY files. Input and output on
+binary streams is supported for all valid PLY files. Note that
+`sys.stdout` and `sys.stdin` are text streams, so they can only be
+used directly for ASCII-format PLY files.
+
 # FAQ
 
 ## How do I initialize a list property from two-dimensional array?
@@ -444,19 +452,10 @@ but modifying that instance will then affect all of those containing
 
 ## Can I save a PLY file directly to `sys.stdout`?
 
-On Python 3, you will probably run into issues because `sys.stdout` is a
-text-mode stream and `plyfile` outputs binary data, even for
-ASCII-format PLY files:
-
-```Python Console
->>> import sys
->>> plydata.write(sys.stdout)
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-    File ".../python-plyfile/plyfile.py", line 411, in write
-        stream.write(self.header.encode('ascii'))
-        TypeError: write() argument must be str, not bytes
-```
+Yes, for an ASCII-format PLY file. For binary-format files, it won't
+work directly, since `sys.stdout` is a text-mode stream and binary-format
+files can only be output to binary streams. (ASCII-format files can be
+output to text or binary streams.)
 
 There are a few ways around this.
 - Write to a named file instead. On Linux and some other Unix-likes, you
@@ -473,6 +472,14 @@ There are a few ways around this.
     ```
 
   (source: https://bugs.python.org/issue4571)
+
+## Can I read a PLY file from `sys.stdin`?
+
+The answer is exactly analogous to the situation with writing to
+`sys.stdout`: it works for ASCII-format PLY files but not binary-format
+files. The two workarounds given above also apply: use a named file like
+`/dev/stdin`, or use `sys.stdin.buffer`.
+
 
 # Design philosophy and rationale
 

--- a/plyfile.py
+++ b/plyfile.py
@@ -97,7 +97,8 @@ class _PlyHeaderLines(object):
             else:
                 self.chars.append(c)
         elif s[3:] != '\n':
-            raise PlyHeaderParseError("unexpected characters after 'ply'", 1)
+            raise PlyHeaderParseError(
+                "unexpected characters after 'ply'", 1)
         self.stream = stream
         self.len_nl = len(self.nl)
         self.done = False
@@ -115,7 +116,8 @@ class _PlyHeaderLines(object):
             while ''.join(self.chars[-self.len_nl:]) != self.nl:
                 char = self._decode(self.stream.read(1))
                 if not char:
-                    raise PlyHeaderParseError("early end-of-file", self.lines)
+                    raise PlyHeaderParseError("early end-of-file",
+                                              self.lines)
                 self.chars.append(char)
             line = ''.join(self.chars[:-self.len_nl])
             self.chars = []

--- a/plyfile.py
+++ b/plyfile.py
@@ -662,8 +662,6 @@ class PlyElement(object):
         if text:
             self._read_txt(stream)
         else:
-            if known_list_len is None:
-                known_list_len = {}
             list_prop_names = set(p.name for p in self.properties
                                   if isinstance(p, PlyListProperty))
             can_mmap_lists = list_prop_names <= set(known_list_len)

--- a/plyfile.py
+++ b/plyfile.py
@@ -22,12 +22,6 @@ import numpy as _np
 from sys import byteorder as _byteorder
 
 
-try:
-    _range = xrange
-except NameError:
-    _range = range
-
-
 # Many-many relation
 _data_type_relation = [
     ('int8', 'i1'),
@@ -780,7 +774,7 @@ class PlyElement(object):
         '''
         self._data = _np.empty(self.count, dtype=self.dtype(byte_order))
 
-        for k in _range(self.count):
+        for k in range(self.count):
             for prop in self.properties:
                 try:
                     self._data[prop.name][k] = \

--- a/plyfile.py
+++ b/plyfile.py
@@ -370,10 +370,10 @@ class PlyData(object):
     """
     PLY file header and data.
 
-    A PlyData instance is created in one of two ways: by the static
-    method PlyData.read (to read a PLY file), or directly from __init__
-    given a sequence of elements (which can then be written to a PLY
-    file).
+    A `PlyData` instance is created in one of two ways: by the static
+    method `PlyData.read` (to read a PLY file), or directly from
+    `__init__` given a sequence of elements (which can then be written
+    to a PLY file).
 
     Attributes
     ----------
@@ -391,15 +391,15 @@ class PlyData(object):
         Parameters
         ----------
         elements : iterable of PlyElement
-        text : bool
+        text : bool, optional
             Whether the resulting PLY file will be text (True) or
             binary (False).
-        byte_order : {'<', '>', '='}
-            '<' for little-endian, '>' for big-endian, or '='
+        byte_order : {'<', '>', '='}, optional
+            `'<'` for little-endian, `'>'` for big-endian, or `'='`
             for native.  This is only relevant if `text` is False.
-        comments : iterable of str
-            Comment lines between 'ply' and 'format' lines.
-        obj_info : iterable of str
+        comments : iterable of str, optional
+            Comment lines between "ply" and "format" lines.
+        obj_info : iterable of str, optional
             like comments, but will be placed in the header with
             "obj_info ..." instead of "comment ...".
         """
@@ -490,6 +490,7 @@ class PlyData(object):
         Raises
         ------
         PlyParseError
+            If the file cannot be parsed for any reason.
         ValueError
             If `stream` is open in text mode but the PLY header
             indicates binary encoding.
@@ -635,7 +636,7 @@ def _open_stream(stream, read_or_write):
     ----------
     stream : str or open file-like object
     read_or_write : str
-        "read" or "write", the method to be used on the stream.
+        `"read"` or `"write"`, the method to be used on the stream.
 
     Returns
     -------
@@ -772,7 +773,7 @@ class PlyElement(object):
 
     def dtype(self, byte_order='='):
         """
-        Return the numpy dtype of the in-memory representation of the
+        Return the `numpy` `dtype` of the in-memory representation of the
         data.  (If there are no list properties, and the PLY format is
         binary, then this also accurately describes the on-disk
         representation of the element.)
@@ -799,14 +800,15 @@ class PlyElement(object):
         data : numpy.ndarray
             Structured `numpy` array.
         len_types : dict, optional
-            Mapping from list property names to type strings (like 'u1',
-            'f4', etc., or 'int8', 'float32', etc.), which will be used
-            to encode the length of the list in binary-format PLY files.
-            Defaults to 'u1' (8-bit integer) for all list properties.
+            Mapping from list property names to type strings
+            (`numpy`-style like `'u1'`, `'f4'`, etc., or PLY-style like
+            `'int8'`, `'float32'`, etc.), which will be used to encode
+            the length of the list in binary-format PLY files.  Defaults
+            to `'u1'` (8-bit integer) for all list properties.
         val_types : dict, optional
             Mapping from list property names to type strings as for `len_types`,
             but is used to encode the list elements in binary-format PLY files.
-            Defaults to 'i4' (32-bit integer) for all list properties.
+            Defaults to `'i4'` (32-bit integer) for all list properties.
         comments : list of str
             Comments between the "element" line and first property definition
             in the header.
@@ -1128,8 +1130,8 @@ class PlyProperty(object):
     """
     PLY property description.
 
-    This class is pure metadata; the data itself is contained in
-    PlyElement instances.
+    This class is pure metadata. The data itself is contained in
+    `PlyElement` instances.
 
     Attributes
     ----------

--- a/plyfile.py
+++ b/plyfile.py
@@ -319,9 +319,6 @@ class PlyData(object):
             "obj_info ..." instead of "comment ...".
 
         '''
-        if byte_order == '=' and not text:
-            byte_order = _native_byte_order
-
         self.byte_order = byte_order
         self.text = text
 
@@ -339,6 +336,8 @@ class PlyData(object):
     elements = property(_get_elements, _set_elements)
 
     def _get_byte_order(self):
+        if not self.text and self._byte_order == '=':
+            return _native_byte_order
         return self._byte_order
 
     def _set_byte_order(self, byte_order):

--- a/plyfile.py
+++ b/plyfile.py
@@ -421,8 +421,8 @@ class PlyData(object):
                 if data.text:
                     data_stream = stream
                 else:
-                    raise PlyParseError("can't read binary-format PLY "
-                                        "from text stream")
+                    raise ValueError("can't read binary-format PLY "
+                                     "from text stream")
             else:
                 if data.text:
                     data_stream = _io.TextIOWrapper(stream, 'ascii')
@@ -519,7 +519,7 @@ def _open_stream(stream, read_or_write):
     try:
         return (True, open(stream, read_or_write[0] + 'b'))
     except TypeError:
-        raise RuntimeError("expected open file or filename")
+        raise TypeError("expected open file or filename")
 
 
 class PlyElement(object):

--- a/plyfile.py
+++ b/plyfile.py
@@ -82,21 +82,6 @@ def _lookup_type(type_str):
     return _data_type_reverse[type_str]
 
 
-def make2d(array, cols=None, dtype=None):
-    '''
-    Make a 2D array from an array of arrays.  The `cols' and `dtype'
-    arguments can be omitted if the array is not empty.
-
-    '''
-    if not len(array):
-        if cols is None or dtype is None:
-            raise RuntimeError(
-                "cols and dtype must be specified for empty array"
-            )
-        return _np.empty((0, cols), dtype=dtype)
-    return _np.vstack(array)
-
-
 class _PlyHeaderParser(object):
     def __init__(self):
         self.format = None

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -201,6 +201,31 @@ end_header\n\
 3 1 2 3 0 0 255\n\
 '''.encode('ascii')
 
+tet_ply_ascii_mac = '''\
+ply\r\
+format ascii 1.0\r\
+comment single tetrahedron with colored faces\r\
+element vertex 4\r\
+comment tetrahedron vertices\r\
+property float x\r\
+property float y\r\
+property float z\r\
+element face 4\r\
+property list uchar int vertex_indices\r\
+property uchar red\r\
+property uchar green\r\
+property uchar blue\r\
+end_header\r\
+0 0 0\r\
+0 1 1\r\
+1 0 1\r\
+1 1 0\r\
+3 0 1 2 255 255 255\r\
+3 0 2 3 255 0 0\r\
+3 0 1 3 0 255 0\r\
+3 1 2 3 0 0 255\r\
+'''.encode('ascii')
+
 np_types = ['i1', 'u1', 'i2', 'u2', 'i4', 'u4', 'f4', 'f8']
 
 
@@ -895,3 +920,10 @@ def test_read_known_list_len_two_lists_same(tmpdir, tet_ply_txt):
     assert e.exc_val.element.name == 'face'
     assert e.exc_val.row == 0
     assert e.exc_val.prop.name == 'vertex_indices'
+
+
+def test_mac_newlines(tet_ply_txt):
+    ply0 = tet_ply_txt
+    f = BytesIO(tet_ply_ascii_mac)
+    ply1 = PlyData.read(f)
+    verify(ply0, ply1)

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -201,31 +201,6 @@ end_header\n\
 3 1 2 3 0 0 255\n\
 '''.encode('ascii')
 
-tet_ply_ascii_mac = '''\
-ply\r\
-format ascii 1.0\r\
-comment single tetrahedron with colored faces\r\
-element vertex 4\r\
-comment tetrahedron vertices\r\
-property float x\r\
-property float y\r\
-property float z\r\
-element face 4\r\
-property list uchar int vertex_indices\r\
-property uchar red\r\
-property uchar green\r\
-property uchar blue\r\
-end_header\r\
-0 0 0\r\
-0 1 1\r\
-1 0 1\r\
-1 1 0\r\
-3 0 1 2 255 255 255\r\
-3 0 2 3 255 0 0\r\
-3 0 1 3 0 255 0\r\
-3 1 2 3 0 0 255\r\
-'''.encode('ascii')
-
 np_types = ['i1', 'u1', 'i2', 'u2', 'i4', 'u4', 'f4', 'f8']
 
 
@@ -922,16 +897,11 @@ def test_read_known_list_len_two_lists_same(tmpdir, tet_ply_txt):
     assert e.exc_val.prop.name == 'vertex_indices'
 
 
-def test_mac_newlines_ascii(tet_ply_txt):
-    ply0 = tet_ply_txt
-    f = BytesIO(tet_ply_ascii_mac)
-    ply1 = PlyData.read(f)
-    verify(ply0, ply1)
-
-
+@pytest.mark.parametrize('text,byte_order',
+                         [(True, '='), (False, '<'), (False, '>')])
 @pytest.mark.parametrize('newline', ['\n', '\r', '\r\n'])
-def test_newlines_binary(newline):
-    ply0 = tet_ply(False, '<')
+def test_newlines_binary(text, byte_order, newline):
+    ply0 = tet_ply(text, byte_order)
     header = ply0.header + '\n'
     header_len = len(header)
 

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -15,12 +15,11 @@ from plyfile import (
 
 
 class Raises(object):
-
-    '''
+    """
     Utility: use as a context manager for code that is expected to raise
     an exception.
+    """
 
-    '''
     def __init__(self, *exc_types):
         self._exc_types = set(exc_types)
 
@@ -52,10 +51,9 @@ def normalize_property(prop):
 
 
 def verify(ply0, ply1):
-    '''
+    """
     Verify that two PlyData instances describe the same data.
-
-    '''
+    """
     el0 = ply0.elements
     el1 = ply1.elements
 
@@ -90,11 +88,10 @@ def verify(ply0, ply1):
 
 
 def verify_1d(prop0, prop1):
-    '''
+    """
     Verify that two 1-dimensional arrays (possibly of type object)
     describe the same data.
-
-    '''
+    """
     n = len(prop0)
     assert len(prop1) == n
 
@@ -113,31 +110,28 @@ def verify_1d(prop0, prop1):
 
 
 def verify_comments(comments0, comments1):
-    '''
+    """
     Verify that comment lists are identical.
-
-    '''
+    """
     assert len(comments0) == len(comments1)
     for (comment0, comment1) in zip(comments0, comments1):
         assert comment0 == comment1
 
 
 def write_read(ply, tmpdir, name='test.ply'):
-    '''
+    """
     Utility: serialize/deserialize a PlyData instance through a
     temporary file.
-
-     '''
+    """
     filename = tmpdir.join(name)
     ply.write(str(filename))
     return PlyData.read(str(filename))
 
 
 def read_str(string, tmpdir, name='test.ply'):
-    '''
+    """
     Utility: create a PlyData instance from a string.
-
-    '''
+    """
     filename = tmpdir.join(name)
     with filename.open('wb') as f:
         f.write(string)

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -8,7 +8,7 @@ import pytest
 
 import numpy
 
-from plyfile import (PlyData, PlyElement, make2d,
+from plyfile import (PlyData, PlyElement,
                      PlyHeaderParseError, PlyElementParseError,
                      PlyProperty)
 
@@ -471,15 +471,6 @@ def test_assign_comments_non_ascii(tet_ply_txt):
 
     with Raises(ValueError):
         ply0['face'].comments = ['\xb0']
-
-
-def test_make2d():
-    a = numpy.empty(2, dtype=object)
-    a[:] = [numpy.array([0, 1, 2]), numpy.array([3, 4, 5])]
-
-    b = make2d(a)
-    assert b.shape == (2, 3)
-    assert (b == [[0, 1, 2], [3, 4, 5]]).all()
 
 
 def test_reorder_elements(tet_ply_txt, tmpdir):

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -16,11 +16,26 @@ from plyfile import (
 
 class Raises(object):
     """
-    Utility: use as a context manager for code that is expected to raise
-    an exception.
+    Context manager for code excpected to raise an exception.
+
+    Exception information is only available after the context has been
+    exited due to a raised exception.
+
+    Attributes
+    ----------
+    exc_type : type
+        The exception type that was raised.
+    exc_val : Exception
+        The raised exception.
+    traceback : traceback
     """
 
     def __init__(self, *exc_types):
+        """
+        Parameters
+        ----------
+        *exc_types : list of type
+        """
         self._exc_types = set(exc_types)
 
     def __enter__(self):
@@ -53,6 +68,15 @@ def normalize_property(prop):
 def verify(ply0, ply1):
     """
     Verify that two PlyData instances describe the same data.
+
+    Parameters
+    ----------
+    ply0 : PlyData
+    ply1 : PlyData
+
+    Raises
+    ------
+    AssertionError
     """
     el0 = ply0.elements
     el1 = ply1.elements

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -347,7 +347,7 @@ def test_copy_on_write(tmpdir, tet_ply_txt):
 
 
 def test_write_invalid_filename(tet_ply_txt):
-    with Raises(RuntimeError) as e:
+    with Raises(TypeError) as e:
         tet_ply_txt.write(None)
 
     assert str(e) == "expected open file or filename"
@@ -949,6 +949,6 @@ def test_text_io_bad_read(tet_ply_txt):
     stream0 = BytesIO()
     ply0.write(stream0)
     stream1 = TextIOWrapper(BytesIO(stream0.getvalue()), 'ascii')
-    with Raises(PlyParseError) as e:
+    with Raises(ValueError) as e:
         ply1 = PlyData.read(stream1)
     assert str(e) == "can't read binary-format PLY from text stream"

--- a/test/test_plyfile.py
+++ b/test/test_plyfile.py
@@ -13,12 +13,6 @@ from plyfile import (PlyData, PlyElement, make2d,
                      PlyProperty)
 
 
-try:
-    _range = xrange
-except NameError:
-    _range = range
-
-
 class Raises(object):
 
     '''
@@ -50,7 +44,7 @@ def normalize_property(prop):
     n = len(prop)
 
     arr = numpy.empty(n, dtype='O')
-    for k in _range(n):
+    for k in range(n):
         arr[k] = prop[k]
 
     return arr
@@ -67,7 +61,7 @@ def verify(ply0, ply1):
     num_elements = len(el0)
     assert len(el1) == num_elements
 
-    for k in _range(num_elements):
+    for k in range(num_elements):
         assert el0[k].name == el1[k].name
 
         data0 = el0[k].data
@@ -79,7 +73,7 @@ def verify(ply0, ply1):
         num_properties = len(dtype0)
         assert len(dtype1) == num_properties
 
-        for j in _range(num_properties):
+        for j in range(num_properties):
             prop_name = dtype0[j][0]
             assert dtype1[j][0] == prop_name
 
@@ -110,7 +104,7 @@ def verify_1d(prop0, prop1):
     s = s0[0]
 
     if s == 'O':
-        for k in _range(n):
+        for k in range(n):
             assert len(prop0[k]) == len(prop1[k])
             assert (prop0[k] == prop1[k]).all()
     else:
@@ -349,22 +343,6 @@ def test_copy_on_write(tmpdir, tet_ply_txt):
     ply2 = PlyData.read(filename)
 
     verify(ply0, ply2)
-
-
-# In Python 3, `unicode' is not a separate type from `str' (and the
-# `unicode' builtin does not exist).  Thus, this test is unnecessary
-# (and indeed would not pass).
-@pytest.mark.skipif(sys.version_info >= (3,),
-                    reason="only relevant on Python 2")
-def test_write_read_unicode_filename(tmpdir, tet_ply_txt):
-    ply0 = tet_ply_txt
-    test_file = tmpdir.join('test.ply')
-    filename = unicode(str(test_file))
-
-    tet_ply_txt.write(filename)
-    ply1 = PlyData.read(filename)
-
-    verify(ply0, ply1)
 
 
 def test_write_invalid_filename(tet_ply_txt):
@@ -683,7 +661,7 @@ invalid_cases = [
 
 
 @pytest.mark.parametrize('s,error_string', invalid_cases,
-                         ids=list(map(str, _range(len(invalid_cases)))))
+                         ids=list(map(str, range(len(invalid_cases)))))
 def test_invalid(tmpdir, s, error_string):
     with Raises(PlyElementParseError) as e:
         read_str(s, tmpdir)
@@ -767,7 +745,7 @@ invalid_header_cases = [
 
 @pytest.mark.parametrize(
     's,line', invalid_header_cases,
-    ids=list(map(str, _range(len(invalid_header_cases))))
+    ids=list(map(str, range(len(invalid_header_cases))))
 )
 def test_header_parse_error(s, line):
     with Raises(PlyHeaderParseError) as e:
@@ -786,7 +764,7 @@ invalid_arrays = [
 
 @pytest.mark.parametrize(
     'a', invalid_arrays,
-    ids=list(map(str, _range(len(invalid_arrays))))
+    ids=list(map(str, range(len(invalid_arrays))))
 )
 def test_invalid_array(a):
     with Raises(ValueError):


### PR DESCRIPTION
Resolves #21.
Resolves #35.
Resolves #52.

(**Note:** this is a somewhat unfocused pull request and thus not a great model for general contributions to this project.)

1. I tried to audit for and remove any code paths whose only purpose was Python 2 compatibility. Hopefully I got everything.
2. I overhauled the logic that splits the PLY header into lines, in order to support all common line ending styles. This should finally resolve #21, at the cost of more complex parsing logic.
3. I added some logic to handle files opened in text mode, removing a common source of confusion. This only applies to ASCII-format files. (This is related to point 1, since it makes use of features specific to Python 3.)
4. I improved docstring style and consistency.