### PR TITLE
half float support

### DIFF
--- a/plyfile.py
+++ b/plyfile.py
@@ -1479,6 +1479,8 @@ _data_type_relation = [
     ('int', 'i4'),
     ('uint32', 'u4'),
     ('uint', 'u4'),
+    ('float16', 'f2'),
+    ('half', 'f2'),
     ('float32', 'f4'),
     ('float', 'f4'),
     ('float64', 'f8'),


### PR DESCRIPTION
Some host applications with PLY file support such as Agisoft Metashape produce half float color (when used with half float image formats such as EXR files).

<!-- readthedocs-preview python-plyfile start -->
----
📚 Documentation preview 📚: https://python-plyfile--76.org.readthedocs.build/en/76/

<!-- readthedocs-preview python-plyfile end -->