### PR TITLE
Switch build backend to pdm-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ Documentation = "https://python-plyfile.readthedocs.io"
 Repository = "https://github.com/dranjan/python-plyfile"
 
 [build-system]
-requires = ["pdm-pep517>=1.0.0"]
-build-backend = "pdm.pep517.api"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 [tool.pdm.scripts]
 test-quick = "pytest test -v"


### PR DESCRIPTION
The pdm-pep517 project was renamed to pdm-backend.

I think based on the migration guide at https://backend.pdm-project.org/migration/ the only change that is required is to switch the backend.

<!-- readthedocs-preview python-plyfile start -->
----
📚 Documentation preview 📚: https://python-plyfile--82.org.readthedocs.build/en/82/

<!-- readthedocs-preview python-plyfile end -->