### PR TITLE
skipping empty lines in header

### DIFF
--- a/plyfile.py
+++ b/plyfile.py
@@ -1149,6 +1149,8 @@ class _PlyHeaderParser(object):
             self._error("early end-of-file")
 
         line = raw_line.strip()
+        if line == '':
+            return
         try:
             keyword = line.split(None, 1)[0]
         except IndexError:


### PR DESCRIPTION
Great work on the plyfile library! We use the point cloud reader in multiple projects to load point clouds with additional scalar fields. While scalar fields are part of the PLY specification and supported by tools like CloudCompare, not many Python packages handle them well.

One prerequisite, of course, is being able to load the point cloud itself. Unfortunately, some companies produce PLY headers that contain empty lines. This isn’t mentioned in the PLY specification, but since tools like Open3D and CloudCompare tolerate it, they get away with it.

We can always strip the empty lines before loading, but it seems like a relatively small adjustment to support this directly in the library. It might be worth considering?