### PR TITLE
Drop official support for Python 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented here.
 - Official suppot for Python 3.14.
 - Official support for NumPy 2.4.
 
+### Removed
+- Official support for Python 3.9.
+
 ## [1.1.3] - 2025-10-21
 ### Changed
 - Skip empty header lines to improve interoperability. Thanks to @JTvD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ description = "PLY file reader/writer"
 authors = [
     {name = "Darsh Ranjan", email = "dranjan@berkeley.edu"},
 ]
-dependencies = ["numpy>=1.21"]
-requires-python = ">=3.9"
+dependencies = ["numpy>=2.0"]
+requires-python = ">=3.10"
 readme = "README.md"
 license = {file = "COPYING"}
 keywords = ["ply", "numpy"]
@@ -33,11 +33,11 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = global-init,py39-numpy{2.0},py310-numpy{2.0,2.1,2.2},py311-numpy{2.0,2.1,2.2,2.3,2.4},py312-numpy{2.0,2.1,2.2,2.3,2.4},py313-numpy{2.1,2.2,2.3,2.4},py314-numpy{2.3,2.4},global-finalize
+envlist = global-init,py310-numpy{2.0,2.1,2.2},py311-numpy{2.0,2.1,2.2,2.3,2.4},py312-numpy{2.0,2.1,2.2,2.3,2.4},py313-numpy{2.1,2.2,2.3,2.4},py314-numpy{2.3,2.4},global-finalize
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
What the title says, and also making sure the doc build and preview still works after some upstream changes.

<!-- readthedocs-preview python-plyfile start -->
----
📚 Documentation preview 📚: https://python-plyfile--85.org.readthedocs.build/en/85/

<!-- readthedocs-preview python-plyfile end -->